### PR TITLE
Fix #27, correct canonical DocBook XSL URI

### DIFF
--- a/en/xml/common/enumerate/number.xsl
+++ b/en/xml/common/enumerate/number.xsl
@@ -4,7 +4,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
   <xsl:import
-    href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/docbook.xsl"/>
+    href="https://cdn.docbook.org/release/xsl/current/xhtml/docbook.xsl"/>
   
   <xsl:template match="d:figure|d:table|d:example" mode="label.markup">
     <xsl:choose>

--- a/en/xml/common/personname/personname.xsl
+++ b/en/xml/common/personname/personname.xsl
@@ -3,7 +3,7 @@
   xmlns:db="http://docbook.org/ns/docbook"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/docbook.xsl"/>
+  <xsl:import href="https://cdn.docbook.org/release/xsl/current/xhtml/docbook.xsl"/>
   
   <xsl:template name="person.lastname">
   <!-- Formats a personal name. Handles corpauthor as a special case. -->

--- a/en/xml/common/titles/titles.xsl
+++ b/en/xml/common/titles/titles.xsl
@@ -4,7 +4,7 @@
   xmlns:d="http://docbook.org/ns/docbook"
   exclude-result-prefixes="d">
   
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/docbook.xsl"/>
+  <xsl:import href="https://cdn.docbook.org/release/xsl/current/xhtml/docbook.xsl"/>
   
   <xsl:template match="d:article">
     <xsl:message>

--- a/en/xml/common/topic.dbxsl-customization.xml
+++ b/en/xml/common/topic.dbxsl-customization.xml
@@ -74,7 +74,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:d="http://docbook.org/ns/docbook">
 
-  &lt;xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/<replaceable
+  &lt;xsl:import href="https://cdn.docbook.org/release/xsl/current/<replaceable
     >FORMAT</replaceable>/docbook.xsl"/>
 
   &lt;!-- Your customizations go here -->

--- a/en/xml/common/xpath.location/docbook-pi.xsl
+++ b/en/xml/common/xpath.location/docbook-pi.xsl
@@ -6,7 +6,7 @@
   exclude-result-prefixes="n">
   
   <xsl:import
-    href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/docbook.xsl"/>
+    href="https://cdn.docbook.org/release/xsl/current/xhtml/docbook.xsl"/>
   
   <xsl:include href="xpathns.location.xsl"/>
   <!--<xsl:include href="xpath.ns.predicate.location.xsl"/>-->

--- a/en/xml/fo/design-titlepages/mybooktitlepage.xsl
+++ b/en/xml/fo/design-titlepages/mybooktitlepage.xsl
@@ -3,7 +3,7 @@
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/fo/docbook.xsl"/>
+  <xsl:import href="https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl"/>
   <xsl:include href="booktitlepage.xsl"/>
   <!-- More customizations hidden -->
 </xsl:stylesheet>

--- a/en/xml/fo/initials/db-initials.xsl
+++ b/en/xml/fo/initials/db-initials.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xsl:stylesheet 
 [
- <!ENTITY db "http://docbook.sourceforge.net/release/xsl-ns/current"> 
+ <!ENTITY db "https://cdn.docbook.org/release/xsl/current"> 
 ]>
 <xsl:stylesheet version="1.0"
   xmlns:d="http://docbook.org/ns/docbook"

--- a/en/xml/fo/initials/initials-float.xsl
+++ b/en/xml/fo/initials/initials-float.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xsl:stylesheet
 [
-  <!ENTITY db "http://docbook.sourceforge.net/release/xsl-ns/current">
+  <!ENTITY db "https://cdn.docbook.org/release/xsl/current">
 ]>
 <xsl:stylesheet version="1.0"
   xmlns:d="http://docbook.org/ns/docbook"

--- a/en/xml/fo/line-height/line-height.xsl
+++ b/en/xml/fo/line-height/line-height.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xsl:stylesheet
 [
-  <!ENTITY db "http://docbook.sourceforge.net/release/xsl-ns/current">
+  <!ENTITY db "https://cdn.docbook.org/release/xsl/current">
 ]>
 <xsl:stylesheet version="1.0"
   xmlns:d="http://docbook.org/ns/docbook"

--- a/en/xml/html/breadcrumbs/chunk4breadcrumbs.xsl
+++ b/en/xml/html/breadcrumbs/chunk4breadcrumbs.xsl
@@ -3,7 +3,7 @@
   xmlns:d="http://docbook.org/ns/docbook"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/chunk.xsl"/>
+  <xsl:import href="https://cdn.docbook.org/release/xsl/current/xhtml/chunk.xsl"/>
   
   <xsl:include href="breadcrumbs2.xsl"/>
   

--- a/en/xml/html/move-toc/db-move-toc.xsl
+++ b/en/xml/html/move-toc/db-move-toc.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xsl:stylesheet [
-  <!ENTITY db "http://docbook.sourceforge.net/release/xsl-ns/current">
+  <!ENTITY db "https://cdn.docbook.org/release/xsl/current">
 ]>
 <xsl:stylesheet 
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"

--- a/en/xml/html/permalinks/db-permalinks.xsl
+++ b/en/xml/html/permalinks/db-permalinks.xsl
@@ -6,7 +6,7 @@
   exclude-result-prefixes="d">
   
   <xsl:import
-    href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/docbook.xsl"/>
+    href="https://cdn.docbook.org/release/xsl/current/xhtml/docbook.xsl"/>
   <xsl:include href="permalinks.xsl"/>
   
   <xsl:include href="component.title.xsl"/>

--- a/en/xml/html/simplenavig/db-simple-navigation.xsl
+++ b/en/xml/html/simplenavig/db-simple-navigation.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xsl:stylesheet [
-  <!ENTITY db "http://docbook.sourceforge.net/release/xsl-ns/current">
+  <!ENTITY db "https://cdn.docbook.org/release/xsl/current">
 ]>
 <xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"

--- a/en/xml/html/syntaxhighlight/sh-google.xsl
+++ b/en/xml/html/syntaxhighlight/sh-google.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xsl:stylesheet [
-  <!ENTITY db "http://docbook.sourceforge.net/release/xsl-ns/current">
+  <!ENTITY db "https://cdn.docbook.org/release/xsl/current">
 ]>
 <xsl:stylesheet version="1.0"
   xmlns:d="http://docbook.org/ns/docbook"

--- a/en/xml/structure/adding-indexterms/add-indexterms.xsl
+++ b/en/xml/structure/adding-indexterms/add-indexterms.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xsl:stylesheet
 [
-  <!ENTITY db "http://docbook.sourceforge.net/release/xsl-ns/current"> 
+  <!ENTITY db "https://cdn.docbook.org/release/xsl/current"> 
 ]>
 <xsl:stylesheet version="1.0"
   xmlns:d="http://docbook.org/ns/docbook"

--- a/en/xml/structure/dublin-core/db2dc.xsl
+++ b/en/xml/structure/dublin-core/db2dc.xsl
@@ -15,7 +15,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
   <xsl:import
-    href="http://docbook.sourceforge.net/release/xsl-ns/current/common/common.xsl"/>
+    href="https://cdn.docbook.org/release/xsl/current/common/common.xsl"/>
   <xsl:import href="copy.xsl"/>
   <xsl:output method="xml" indent="yes"/>
   

--- a/en/xml/structure/splitdb/dbsplit.xsl
+++ b/en/xml/structure/splitdb/dbsplit.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xsl:stylesheet 
 [
- <!ENTITY db "http://docbook.sourceforge.net/release/xsl-ns/current"> 
+ <!ENTITY db "https://cdn.docbook.org/release/xsl/current"> 
 ]>
 <xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"


### PR DESCRIPTION
Fixes #27 

Changes proposed in this pull request:
* Changed from "http://docbook.sourceforge.net/release/xsl-ns/" to "https://cdn.docbook.org/release/xsl/"

@der-schmelle2 could you have a look if everything is ok?