### PR TITLE
WIP: Using and Preserving Entities

### DIFF
--- a/DocBook-Cookbook.xpr
+++ b/DocBook-Cookbook.xpr
@@ -1665,6 +1665,7 @@
                 <file name="en/xml/structure/topic.sectX-to-section.xml"/>
                 <file name="en/xml/structure/topic.splitdb.xml"/>
                 <file name="en/xml/structure/topic.splitting-into-topics.xml"/>
+                <file name="en/xml/structure/topic.use-entities.xml"/>
             </folder>
             <folder path="en/xml/common/"/>
             <file name="en/xml/dbc-common.xml"/>

--- a/en/xml/dbc-structure.xml
+++ b/en/xml/dbc-structure.xml
@@ -95,6 +95,7 @@
   <xi:include href="structure/topic.splitting-into-topics.xml"/>
   <xi:include href="structure/topic.assemble-topics.xml"/>
   <xi:include href="structure/topic.create-assembly-file.xml"/>
-  <!--<xi:include href="structure/topic.preserve-entities.xml"/>-->
+  <xi:include href="structure/topic.use-entities.xml"/>
+  <xi:include href="structure/topic.preserve-entities.xml"/>
   <!--<xi:include href="structure/topic.impl-style-checking.xml"/>-->
 </chapter>

--- a/en/xml/structure/entities/ents2pi.py
+++ b/en/xml/structure/entities/ents2pi.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+#
+# Purpose:
+#  Converts each XML entity (like &product;) into a processing
+#  instruction <?entity product?>
+#
+# Author: 2018, Thomas Schraitle
+
+from __future__ import print_function
+
+import os
+import sys
+from contextlib import contextmanager
+from shutil import copystat
+from tempfile import NamedTemporaryFile
+
+from lxml import etree
+
+
+@contextmanager
+def backup(filename, ext=".bak"):
+    """Context manager for making a backup from a XML file
+
+     :param str filename: the XML filename
+     :param str ext: file extension for the backup (default '.bak')
+    """
+    # split into dirname and basename:
+    dirname, basename = os.path.split(filename)
+    tmp = NamedTemporaryFile(dir=dirname if dirname else ".",
+                             prefix=".{}".format(basename),
+                             # encoding="utf-8",
+                             delete=False)
+    try:
+        yield tmp
+    finally:
+        bak = filename + ext
+        tmp.close()
+        copystat(filename, tmp.name)
+        os.rename(filename, bak)
+        os.rename(tmp.name, filename)
+        print("%s -> %s" % (filename, bak))
+
+
+def replace_entity(tree):
+    """Replace entities in XML tree
+
+     :param tree: the XML tree
+     :type tree: :class:`lxml.etree._ElementTree`
+    """
+    # We are only interested in entities:
+    DBURI = "http://docbook.org/ns/docbook"
+    for ent in tree.iter(etree.Entity):
+        name = ent.name
+        parent = ent.getparent()
+        #  phrase = etree.Element("{%s}phrase" % DBURI,
+        #                         attrib={'role': 'ent'},
+        #                         nsmap={None: DBURI})
+        #  phrase.text = name
+        pi = etree.ProcessingInstruction("entity", name)
+        parent.replace(ent, pi)
+
+
+def process(xmlfile):
+    """Process a single XML file and replace its entities
+
+    :param str xmlfile: the XML file
+    :return: zero means success
+    :rtype: int
+    """
+    parser = etree.XMLParser(resolve_entities=False, collect_ids=False)
+    with backup(xmlfile) as tmp:
+        tree = etree.parse(xmlfile, parser=parser)
+        replace_entity(tree)
+        tree.write(tmp, encoding="utf-8",)
+
+    return 0
+
+
+def main(xmlfiles):
+    """Process XML file and replace any custom entities with the
+      element <phrase role="ent">entname</phrase>
+
+    :param str xmlfile: path to the XML file
+    :return: zero means success
+    :rtype: int
+    """
+
+    for xml in xmlfiles:
+        res = process(xml)
+    return res
+
+
+if __name__ == "__main__":
+    try:
+        if not os.path.exists(sys.argv[1]):
+            print("ERROR: File %r does not exist" % sys.argv[1], file=sys.stderr)
+            sys.exit(1)
+        result = main(sys.argv[1:])
+        sys.exit(result)
+    excecpt etree.XMLSyntaxError as err:
+        print(err, file=sys.stderr)
+        sys.exit(10)
+    except IndexError:
+        print("ERROR: Need a DocBook file", file=sys.stderr)
+        sys.exit(20)

--- a/en/xml/structure/entities/ents2text.py
+++ b/en/xml/structure/entities/ents2text.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+#
+# Purpose:
+#  Converts each XML entity (like &product;) into [[[product]]]
+#  and vice versa.
+#
+#  Depending how the script is called (either as ent2text.py or
+#  as text2ent.py, the right mode is selected automatically.
+#
+# Author: 2018, Thomas Schraitle
+
+import fileinput
+import os
+import re
+import sys
+
+# Matches custom entities, but not default like &lt; etc.
+ENT = re.compile(r"\&((?!lt|amp|quot|apos|gt)[^;]*);")
+
+# Matches our protected text [[[X]]]
+TXT = re.compile(r"\[\[\[([^\]]*)\]\]\]")
+
+BASENAME = os.path.basename(__file__)
+
+
+def ent2text(fileobj):
+    """Converts entities into marked text:
+       &product; -> [[[product]]]
+
+    :param fileobj: file object from context manager
+    :type fileobj: :class:`fileinput.FileInput`
+    """
+    for line in fileobj:
+        if fileinput.isfirstline():
+            sys.stderr.write(">> %s\n" % fileinput.filename())
+        print(ENT.sub(r"[[[\1]]]", line), end="")
+
+
+def text2ent(fileobj):
+    """Converts marked text into entities:
+       [[[product]]] -> &product;
+
+    :param fileobj: file object from context manager
+    :type fileobj: :class:`fileinput.FileInput`
+    """
+    for line in fileobj:
+        if fileinput.isfirstline():
+            sys.stderr.write(">> %s\n" % fileinput.filename())
+        print(TXT.sub(r"&\1;", line), end="")
+
+
+if BASENAME.startswith("ents2text") or BASENAME.startswith("ents2txt"):
+    transform = ent2text
+elif BASENAME.startswith("text2ents") or BASENAME.startswith("txt2ents"):
+    transform = text2ent
+else:
+    print("ERROR: The script should be named ents2text, ents2txt, "
+          "text2ents, or txt2ents.", file=sys.stderr)
+    sys.exit(10)
+
+
+def main():
+    """Main entry point
+
+    :return: return code zero
+    """
+    with fileinput.input(inplace=True, backup='.bak') as f:
+        transform(f)
+    return 0
+
+
+def usage():
+    """Print usage and exit with return code 1"""
+    print("""Syntax:
+
+  %s XMLFILE...
+            """ % BASENAME)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or sys.argv[1] in ('-h', '--help'):
+        usage()
+    sys.exit(main())

--- a/en/xml/structure/topic.db4-to-db5.xml
+++ b/en/xml/structure/topic.db4-to-db5.xml
@@ -24,6 +24,7 @@
     <definitions definitionfile="defs.xml"/>
     <keywordset>
       <keyword>converting</keyword>
+      <keyword>migrating</keyword>
       <keyword>DocBook 4</keyword>
       <keyword>DocBook 5</keyword>
     </keywordset>
@@ -33,6 +34,7 @@
     <title>Problem</title>
     <para>You have a DocBook document in version 4.x, but you need 5.x.</para>
   </section>
+
   <section role="solution">
     <title>Solution</title>
     <para>Generally, the difference between version 4 and version 5 is
@@ -44,77 +46,36 @@
     <para>One major change is that all DocBook 5.x elements are in the
       namespace <uri>http://docbook.org/ns/docbook</uri>. All these
       changes are taken into account by the
-        <filename>db4-upgrade.xsl</filename> stylesheet in the DocBook
-      Subversion repository. The URL is <link
-        xlink:href="https://docbook.svn.sourceforge.net/svnroot/docbook/trunk/docbook/relaxng/tools/db4-upgrade.xsl"
+        <filename>db4-upgrade.xsl</filename>, see the URL <link
+        xlink:href="https://github.com/docbook/docbook/blob/master/relaxng/tools/db4-upgrade.xsl"
       />. You just need to apply this stylesheet to your source DocBook
       document, for example:</para>
-    <screen><command>xsltproc</command> db4-upgrade.xsl doc.xml</screen>
+    <screen><prompt>$ </prompt><command>xsltproc</command> --output doc5.xml db4-upgrade.xsl doc.xml</screen>
+    <para>After the migration, the file <filename>doc5.xml</filename> contains
+    your DocBook5 source.</para>
   </section>
+
   <section role="discussion">
     <title>Discussion</title>
     <para>One disadvantage is that entities are not preserved. This is
-      not a stylesheet issue as the entities are already resolved when
-      the XSLT processor gets its hand on the source tree. The
+      not a stylesheet issue but a XML issue. The entities are already
+      resolved when the XSLT processor gets its hand on the source tree. The
       stylesheet never sees the entities.
     </para>
-    <para>The <citetitle
-      xlink:href="http://docbook.org/docs/howto/#entities">DocBook
-      Transition Guide</citetitle> recommends the following steps (cited
-      from there):</para>
-    <procedure xml:id="pr.structure.db4-to-db5.preserving-entities">
-      <title>Preserving Entities between DocBook Conversion</title>
-      <step>
-        <para>Open your existing document using your favorite editing
-          tool. You must use a tool that is <emphasis>not</emphasis>
-          XML-aware, or one that allows you to edit markup <quote>in
-            the raw</quote>.</para>
-      </step>
-      <step>
-        <para>Replace all occurrences of the entity references that you
-          want to preserve with some unique string. For example, if you
-          want to preserve <tag class="genentity">Product</tag>
-          references, you could replace them all with
-            <literal>[[[Product]]]</literal> (assuming that the string
-            <literal>[[[Product]]]</literal> doesn't occur anywhere else
-          in your document).</para>
-      </step>
-      <step>
-        <para>Copy the document type declaration of your document
-          and save it some place. The document type declaration is
-          everything from “&lt;!DOCTYPE” to the closing “]>”. </para>
-      </step>
-      <step>
-        <para>Perform the conversion with the
-          <filename>db4-upgrade.xsl</filename> stylesheet.</para>
-      </step>
-      <step>
-        <para>Open the new document using your favorite editing tool.
-          Replace all occurrences of the unique string you used to save
-          the entity references with the corresponding entity
-          references.</para>
-      </step>
-      <step>
-        <para>Paste the document type declaration that you saved onto
-          the top of your new document.</para>
-      </step>
-      <step>
-        <para>Remove the external identifier (the PUBLIC and/or SYSTEM
-          keywords) from the document type declaration. A document that
-          begins with:</para>
-        <screen>&lt;!DOCTYPE book [
- &lt;!ENTITY someEntity "some replacement text">
-]></screen>
-        <para>is perfectly well-formed. If you don't remove the
-          references to the DTD, then your parser will likely try to
-          validate against DocBook V4.0 and that's not going to work.
-          Alternatively, you could refer to the DocBook V5.0 DTD.</para>
-      </step>
-    </procedure>
+    <para>In cases you need to leave your entities untouched, refer to
+    <xref linkend="dbc.structure.preserve-entities"/>.</para>
   </section>
+
   <section role="seealso">
     <title>See Also</title>
-    <para>Further information can be found in <link
-      xlink:href="http://docbook.org/docs/howto/#convert4to5"/>.</para>
+    <itemizedlist>
+      <listitem>
+        <para><xref linkend="dbc.structure.preserve-entities"/></para>
+      </listitem>
+      <listitem>
+        <para><link
+      xlink:href="http://docbook.org/docs/howto/#convert4to5"/></para>
+      </listitem>
+    </itemizedlist>
   </section>
 </section>

--- a/en/xml/structure/topic.preserve-entities.xml
+++ b/en/xml/structure/topic.preserve-entities.xml
@@ -14,33 +14,215 @@
 
 -->
 
-<!--<?xml-model href="file:../5.1/dbref.rnc" type="application/relax-ng-compact-syntax"?>-->
-<section xml:id="dbc.structure.preserve-entities" remap="topic"
+<?xml-model href="file:../5.1/dbref.rnc" type="application/relax-ng-compact-syntax"?>
+<section xml:id="dbc.structure.preserve-entities" remap="topic" version="5.1"
    xmlns="http://docbook.org/ns/docbook"
    xmlns:xi="http://www.w3.org/2001/XInclude"
    xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Preserving Entities</title>
   <info>
-    <definitions definitionfile="defs.xml"/>
     <keywordset>
       <keyword>preserving entities</keyword>
+      <keyword>entities</keyword>
+      <keyword>placeholders</keyword>
     </keywordset>
+    <subjectset>
+      <subject>
+        <subjectterm>entities</subjectterm>
+      </subject>
+    </subjectset>
   </info>
 
   <section role="problem">
     <title>Problem</title>
-    <para>The problem explained.</para>
+    <para>You want to process your XML file, but you do not want to expand
+      any of the defined entities.</para>
   </section>
   <section role="solution">
     <title>Solution</title>
-    <para>The solution explained</para>
+    <para>
+      Replace all your entities with a string that is easy to search for. For
+      example, you can replace the entity <tag class="genentity">product</tag>
+      with the string <literal>[[[product]]]</literal> (assuming that the
+      string <literal>[[[product]]]</literal> doesn't occur anywhere else in
+      our document).
+    </para>
+    <para>This can be done automatically with the following procedure:
+    </para>
+
+    <procedure xml:id="pro.structure.preserve-entities.workflow">
+      <title>Workflow for Protecting Custom Entities</title>
+      <step>
+        <para>Make sure you have Python&#xa0;3 installed on your system. Find
+          installation instructions on the project's home page at <link
+            xlink:href="https://www.python.org/"/>. The script works with Python
+          3.4 and above.</para>
+        <para>
+         On Linux or macOS Python may already be installed. If that is not
+         the case, Python can be installed using the system's package manager.
+        </para>
+      </step>
+      <step>
+        <para>Download the Python script <filename
+          xlink:href="#li.structure.preserve-entities.ents2text"
+          >ents2text.py</filename><!--
+          from <link
+            xlink:href="https://github.com/tomschr/dbcookbook/raw/develop/en/xml/structure/entities/ents2text.py"/>
+          -->.
+        </para>
+      </step>
+      <step>
+        <para>Save the script where it can be found by the system. Linux users
+          can store the script in either <filename class="directory"
+            >~/bin</filename> or <filename class="directory"
+          >/usr/bin</filename>. In this procedure, we use <filename
+            class="directory">~/bin</filename>. Make the script executable
+          with:</para>
+        <screen><prompt>$ </prompt><command>chmod</command> +x ~/bin/ents2text.py</screen>
+      </step>
+      <step>
+        <para>Create a link:</para>
+        <screen><prompt>$ </prompt><command>ln</command> -rs ~/bin/ents2text.py ~/bin/text2ents.py</screen>
+        <para>This is required for converting from entities to text and
+          vice versa. The script uses the script's name to determine the
+          conversion direction.</para>
+      </step>
+      <step>
+        <para>Convert all entities to text with the following command:</para>
+        <screen><prompt>$ </prompt><command>ents2text.py</command> XMLFILE1 XMLFILE2...</screen>
+        <para>The script converts all entities to their protected notation in
+          place and creates backup files with the extension <filename
+            class="extension">.bak</filename>.</para>
+      </step>
+      <step>
+        <para>Process your XML file with your XML tools.</para>
+      </step>
+      <step>
+        <para>Revert all the protected notation to their original entity
+          notation:</para>
+        <screen><prompt>$ </prompt><command>text2ents.py</command> XMLFILE1 XMLFILE2...</screen>
+      </step>
+    </procedure>
   </section>
   <section role="discussion">
     <title>Discussion</title>
-    <para>Some discussion about problem and solution.</para>
+    <para><emphasis>Not</emphasis> expanding entities looks like
+      an abnormal use case as XML parsers are supposed to expand entities by
+      default.
+      However, expanding entities has one disadvantage: after the XML parser
+      has resolved entities, the content is indistinguishable from other
+      content. In other words, you cannot distinguish content that comes
+      from an entity definition from existing content. You cannot
+      <quote>go back</quote> and revert this process once all entities are
+      expanded.
+    </para>
+    <para>
+      For this reason, preserving entities can be useful when you want to
+      process XML, but keep the definied entities untouched. <xref
+        linkend="pro.structure.preserve-entities.workflow"
+        xrefstyle="select:label"/> showed one solution. However, be aware
+      of certain issues that might cause problems with XML files:
+    </para>
+
+    <itemizedlist>
+      <listitem>
+        <para>The script does not know XML. As such, it reads the XML file
+          line by line and replaces each line through regular expressions.</para>
+      </listitem>
+      <listitem>
+        <para>The script can replace entities in situations where it is
+        not desirable. For example, if you have an entity in an <tag
+          class="attribute">href</tag> of a <tag>xi:include</tag> element,
+          such reference will not work anymore when resolving XIncludes.
+        </para>
+      </listitem>
+      <listitem>
+        <para>The script doesn't handle external entities.
+          External entities refer to external storage objects,
+          for example:
+        </para>
+        <programlisting language="xml">&lt;!DOCTYPE book [
+  <emphasis role="bold">&lt;!ENTITY intro SYSTEM "chap-intro.xml"></emphasis>
+]>
+&lt;book>
+  &lt;title>...&lt;/title>
+  <emphasis role="bold">&amp;intro;</emphasis>
+&lt;/book></programlisting>
+        <para>Such external entities usually refer to whole XML structures
+          like chapters, sections etc.
+          Replacing such structures with ordinary text would lead to syntax
+          errors in your XML files.
+          However, such entities are not used very often and they should be
+          replaced by XInludes (see
+          <xref linkend="dbc.markup.xincludes"/>).
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <para>If you prefer a solution that can handle XML, use the Python
+      script <filename xlink:href="#li.structure.preserve-entities.ents2pi"
+        >ents2pi.py</filename>.
+      This script can parse XML and replaces each entity with a processing
+      instruction. For example, the entity <tag class="genentity">product</tag>
+      is converted to the PI <tag class="pi">entity product</tag>. That makes
+      it easier to process it with XSLT or any other XML-agnostic tool.
+    </para>
+
+    <table xml:id="tab.structure.preserve-entities.comparison">
+      <title>Comparison Between <filename>ent2text.py</filename> and <filename>ents2pi.py</filename></title>
+      <tgroup cols="3">
+        <thead>
+          <row>
+            <entry morerows="1"></entry>
+            <entry><filename>ent2text.py</filename></entry>
+            <entry><filename>ents2pi.py</filename></entry>
+          </row>
+          <row>
+            <entry>Entity to Text</entry>
+            <entry>Entity to PI</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry>XML-aware</entry>
+            <entry>No</entry>
+            <entry>Yes</entry>
+          </row>
+          <row>
+            <entry>Easy to process it further</entry>
+            <entry>More difficult</entry>
+            <entry>Easy</entry>
+          </row>
+          <row>
+            <entry>Preserving source code</entry>
+            <entry>Always</entry>
+            <entry>Usually</entry>
+          </row>
+          <row>
+            <entry>Dependencies</entry>
+            <entry>Only Python standard library</entry>
+            <entry><package>lxml</package><footnote>
+              <para>See <link xlink:href="https://pypi.org/project/lxml/"/></para>
+            </footnote></entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
   </section>
   <section role="seealso">
     <title>See Also</title>
-    <para></para>
+    <itemizedlist>
+      <listitem>
+        <para><xref linkend="dbc.structure.use-entities"/></para>
+      </listitem>
+      <listitem xml:id="li.structure.preserve-entities.ents2text">
+        <para><link
+        xlink:href="https://github.com/tomschr/dbcookbook/raw/develop/en/xml/structure/entities/ents2text.py"/></para>
+      </listitem>
+      <listitem xml:id="li.structure.preserve-entities.ents2pi">
+        <para><link
+        xlink:href="https://github.com/tomschr/dbcookbook/raw/develop/en/xml/structure/entities/ents2pi.py"/></para>
+      </listitem>
+    </itemizedlist>
   </section>
 </section>

--- a/en/xml/structure/topic.use-entities.xml
+++ b/en/xml/structure/topic.use-entities.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    License CC BY-NC-SA 3.0
+
+   This work is licensed under the
+   "Namensnennung – Keine kommerzielle Nutzung – Weitergabe unter
+    gleichen Bedingungen 3.0 Deutschland (CC BY-NC-SA 3.0)"
+   http://creativecommons.org/licenses/by-nc-sa/3.0/de/deed.de
+
+   Read the English translation here:
+
+   "Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)"
+   http://creativecommons.org/licenses/by-nc-sa/3.0/
+
+-->
+<!--<?xml-model href="file:../5.1/dbref.rnc" type="application/relax-ng-compact-syntax"?>-->
+
+<section xml:id="dbc.structure.use-entities" remap="topic" version="5.1"
+   xmlns="http://docbook.org/ns/docbook"
+   xmlns:xi="http://www.w3.org/2001/XInclude"
+   xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Using Entities as Placeholders</title>
+  <info>
+    <keywordset>
+      <keyword>entities</keyword>
+      <keyword>placeholders</keyword>
+    </keywordset>
+    <subjectset>
+      <subject>
+        <subjectterm>entities</subjectterm>
+      </subject>
+    </subjectset>
+  </info>
+
+  <section role="problem">
+    <title>Problem</title>
+    <para>You need text or a small XML structure that you want to use throughout
+      your document.</para>
+  </section>
+  <section role="solution">
+    <title>Solution</title>
+    <para>Use custom entities. An entity is a placeholder for text or XML. You
+      can define them inside a DOCTYPE declaration or in external files. The
+      following procedure shows you how to create and use a entity:</para>
+
+    <procedure>
+      <step>
+        <para>Create a new <filename class="extension"
+          >.ent</filename> file, for example, <filename>entities.ent</filename>.
+        </para>
+      </step>
+      <step>
+        <para>Add your entity definitions to the file.</para>
+        <para>Each definition starts with <literal>&lt;!ENTITY</literal>, the
+          entity name, the content, and a final > character like this:</para>
+        <screen language="xml">&lt;!ENTITY product "FooMatic"></screen>
+        <para>You can add as many entity definitions as you like. Keep in mind
+          the following restrictions:</para>
+        <itemizedlist>
+          <listitem>
+            <para>If your content contains characters like &lt; or &amp;,
+              write them as <tag class="genentity">lt</tag> and <tag
+                class="genentity">amp</tag>.</para>
+          </listitem>
+          <listitem>
+            <para>It is allowed to use other entities like this:</para>
+            <screen language="xml">&lt;!ENTITY version "2.5">
+&lt;!ENTITY product "FooMatic">
+&lt;!ENTITY productver "&amp;product; &amp;version;"></screen>
+            <para>However, it is not allowed to create circular references
+            like this:</para>
+            <screen language="xml">&lt;!ENTITY a "&amp;b;">
+&lt;!ENTITY b "&amp;a;"></screen>
+          </listitem>
+          <listitem>
+            <para>If you use XML structures in your entity, the content
+            of the entity must be well-formed. This is allowed:</para>
+            <screen>&lt;!ENTITY x "&lt;foo>x&lt;/foo>"></screen>
+            <para>However, this is not:</para>
+            <screen>&lt;!ENTITY x-start "&lt;foo>x">
+&lt;!ENTITY x-end "&lt;/foo>"></screen>
+          </listitem>
+        </itemizedlist>
+      </step>
+      <step>
+        <para>In each file where you want to use your entity definitions, add
+        the following header and replace <replaceable>ROOT</replaceable> with
+        the name of the root element:</para>
+        <screen language="xml">&lt;!DOCTYPE <replaceable>ROOT</replaceable> [
+  &lt;!ENTITY % ents SYSTEM "entities.ent">
+  %ents;
+]></screen>
+      </step>
+      <step>
+        <para>To use the definied entities, write <tag class="genentity">product</tag>
+        in a text, for example:</para>
+        <screen language="xml">&lt;para>Use <emphasis role="bold"
+          >&amp;product;</emphasis> to make your children happy.&lt;/para></screen>
+      </step>
+    </procedure>
+  </section>
+  <section role="discussion">
+    <title>Discussion</title>
+    <para>Entities improve the consistency of your texts. If your product
+      name, your version, or any other definition changes, it is
+      very easy to change its definition too, without going through all of
+      your texts.
+    </para>
+    <para>Entities can contain text and XML. For example, if you have text where
+      you need to add the same file name repeatedly, it would be a good
+      idea to create a entity:</para>
+    <screen language="xml">&lt;!ENTITY configfile "&lt;filename<!--
+--> xmlns='http://docbook.org/ns/docbook'>foo.conf&lt;/filename>"></screen>
+    <para>The only problem with XML structures in entities is, you need to
+    add the DocBook namespace in each definition. By default, each XML element
+    belongs to no namespace.</para>
+  </section>
+  <section role="seealso">
+    <title>See Also</title>
+    <itemizedlist>
+      <listitem>
+        <para><xref linkend="dbc.structure.preserve-entities"/></para>
+      </listitem>
+    </itemizedlist>
+  </section>
+</section>


### PR DESCRIPTION
Fixes #43 

Changes proposed in this pull request:
* Add two scripts with a different approach (entity -> text, entity -> PI)
* Add two topics/files:
  * "Using Entities as Placeholders", file `structure/topic.use-entities.xml`
  * "Preserving Entities". file `structure/topic.preserve-entities.xml`
* Correct `structure/topic.db4-to-db5.xml` to link to the "Preserving Entities" topic.

TODO:
* [x] Fix `structure/entities/ents2pi.py` to allow multiple files and use the same behaviour as `ents2text.py` (create a backup file and change in-place)