### PR TITLE
Add a missing slash for closing tag

### DIFF
--- a/en/xml/db/topic.programlistings.xml
+++ b/en/xml/db/topic.programlistings.xml
@@ -86,7 +86,7 @@ def sayhello(name):
   return "Hello %s" % name
 
 sayhello("Tux")
-&lt;programlisting></programlisting>
+&lt;/programlisting></programlisting>
       <para>Line annotations are printed in italic by default:</para>
       <programlisting language="python" linenumbering="unnumbered"
 >#!/usr/bin/python <lineannotation>Shebang line</lineannotation>


### PR DESCRIPTION
Fixes an example for programlisting element.

Changes proposed in this pull request:
* Use `</programlisting>` for closing tag, instead of original `<programlisting>`